### PR TITLE
Stabilize `integration-test-result` placement via filtering by `external_id`

### DIFF
--- a/.github/actions/get-latest-check/action.yml
+++ b/.github/actions/get-latest-check/action.yml
@@ -16,9 +16,9 @@ runs:
   steps:
     - name: Attach integration-test-result check
       id: attach-check
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       env:
-        CREATE_IF_NEEDED: "${{ inputs.create-if-needed }}"
+        CREATE_IF_NEEDED: '${{ inputs.create-if-needed }}'
       with:
         result-encoding: string
         script: |

--- a/.github/actions/get-latest-check/action.yml
+++ b/.github/actions/get-latest-check/action.yml
@@ -16,9 +16,9 @@ runs:
   steps:
     - name: Attach integration-test-result check
       id: attach-check
-      uses: actions/github-script@v7
+      uses: actions/github-script@v6
       env:
-        CREATE_IF_NEEDED: '${{ inputs.create-if-needed }}'
+        CREATE_IF_NEEDED: "${{ inputs.create-if-needed }}"
       with:
         result-encoding: string
         script: |

--- a/.github/workflows/manage-integration-check.yml
+++ b/.github/workflows/manage-integration-check.yml
@@ -22,10 +22,9 @@ jobs:
               ...context.repo,
               ref: head_sha,
               check_name: "integration-test-result",
-              external_id,
             })
             core.debug(`integration-test-result check runs: ${JSON.stringify(runs, null, 2)}`);
-            const filtRuns = runs.filter(run => run.status !== 'completed');
+            const filtRuns = runs.filter(run => run.status !== 'completed' && run.external_id === external_id);
             const descRuns = filtRuns.sort((a, b) => Date.parse(b.started_at) - Date.parse(a.started_at));
             const run = descRuns[0];
 
@@ -62,10 +61,9 @@ jobs:
               ...context.repo,
               ref: head_sha,
               check_name: "integration-test-result",
-              external_id,
             })
             core.debug(`integration-test-result check runs: ${JSON.stringify(runs, null, 2)}`);
-            const filtRuns = runs.filter(run => run.status !== 'completed');
+            const filtRuns = runs.filter(run => run.status !== 'completed' && run.external_id === external_id);
             const descRuns = filtRuns.sort((a, b) => Date.parse(b.started_at) - Date.parse(a.started_at));
             const run = descRuns[0];
 

--- a/.github/workflows/manage-integration-check.yml
+++ b/.github/workflows/manage-integration-check.yml
@@ -16,7 +16,7 @@ jobs:
         if: ${{ github.event.action == 'requested' || github.event.action == 'in_progress' }}
         with:
           script: |
-            const external_id = context.payload.workflow_run.html_url;
+            const external_id = context.payload.workflow_run.html_url + "-" + context.payload.workflow_run.run_attempt;
             const head_sha = context.payload.workflow_run.head_sha;
             const runs = await github.paginate(github.rest.checks.listForRef, {
               ...context.repo,
@@ -55,7 +55,7 @@ jobs:
           result-encoding: string
           script: |
             // Update the check run
-            const external_id = context.payload.workflow_run.html_url;
+            const external_id = context.payload.workflow_run.html_url + "-" + context.payload.workflow_run.run_attempt;
             const head_sha = context.payload.workflow_run.head_sha;
             const runs = await github.paginate(github.rest.checks.listForRef, {
               ...context.repo,


### PR DESCRIPTION
This PR makes `integration-test-result` consistently placed as `Integration tests / integration-test-result`):
![image](https://github.com/user-attachments/assets/2d340dd4-709d-499a-8584-82ea9f787ba5)

Past runs without this PR's changes have random placement of `integration-test-result` (a data race while creating checks that's really easy to lose):

- #26 `Normal tests / integration-test-result`:
![image](https://github.com/user-attachments/assets/f22752f7-5830-48ec-b4f6-fd7efb20db6f)

- Agoric/agoric-sdk#11209 `Pre-merge checks / integration-test-result`:
![image](https://github.com/user-attachments/assets/70329949-0987-46e9-a15d-b104d29a61ec)

- Agoric/agoric-sdk#11216 `Test Golang / integration-test-result`
![image](https://github.com/user-attachments/assets/8a283032-a13a-4f9a-a73b-629aa1c96971)

- Agoric/agoric-sdk#11188 `Protobuf / integration-test-result`
![image](https://github.com/user-attachments/assets/a41878cb-d0fe-45ed-9025-b1fc27b37580)
